### PR TITLE
Set initial condition in the init function of the operator

### DIFF
--- a/examples/burgers_1d.py
+++ b/examples/burgers_1d.py
@@ -43,10 +43,6 @@ discretization = DiscontinuousGalerkin(burgers_flux, burgers_flux_derivative,
                                        inverse_transformation, LOCAL_SPACE_GRID_SIZE,
                                        LOCAL_TIME_GRID_SIZE)
 
-grid_operator = GridOperator(space_time_grid, discretization, DGFunction,
-                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
-                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
-
 
 def u_0_function(x, jumps=False):
     if jumps:
@@ -54,11 +50,13 @@ def u_0_function(x, jumps=False):
     return 0.5 * (1.0 + np.cos(2.0 * np.pi * x)) * (0.0 <= x <= 0.5) + 0. * (x > 0.5)
 
 
-u_0 = grid_operator.interpolate(u_0_function)
+grid_operator = GridOperator(space_time_grid, discretization, DGFunction, u_0_function,
+                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
+                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
 
-plot_space_function(u_0, title='Initial condition interpolated to DG space')
+plot_space_function(grid_operator.u_0, title='Initial condition interpolated to DG space')
 
-u = grid_operator.solve(u_0)
+u = grid_operator.solve()
 
 plot_space_time_function(u, inverse_transformation, title='Spacetime solution')
 

--- a/examples/burgers_1d_parametrized.py
+++ b/examples/burgers_1d_parametrized.py
@@ -61,21 +61,19 @@ def main(MU: float = Option(1., help='Parameter mu that determines the velocity'
                                            inverse_transformation, LOCAL_SPACE_GRID_SIZE,
                                            LOCAL_TIME_GRID_SIZE)
 
-    grid_operator = GridOperator(space_time_grid, discretization, DGFunction,
-                                 TimeStepperType=RungeKutta4,
-                                 local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
-                                 local_time_grid_size=LOCAL_TIME_GRID_SIZE)
-
     def u_0_function(x, jumps=True):
         if jumps:
             return 1. * (x <= 0.25) + 0.25 * (0.25 < x <= 0.5)
         return 0.5 * (1.0 + np.cos(2.0 * np.pi * x)) * (0.0 <= x <= 0.5) + 0. * (x > 0.5)
 
-    u_0 = grid_operator.interpolate(u_0_function)
+    grid_operator = GridOperator(space_time_grid, discretization, DGFunction, u_0_function,
+                                 TimeStepperType=RungeKutta4,
+                                 local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
+                                 local_time_grid_size=LOCAL_TIME_GRID_SIZE)
 
-    plot_space_function(u_0, title='Initial condition interpolated to DG space')
+    plot_space_function(grid_operator.u_0, title='Initial condition interpolated to DG space')
 
-    u = grid_operator.solve(u_0)
+    u = grid_operator.solve()
 
     u_plot_3d = plot_space_time_function(u, inverse_transformation,
                                          title=r'Spacetime solution for $\mu=$' + str(MU),

--- a/examples/linear_transport_1d.py
+++ b/examples/linear_transport_1d.py
@@ -52,10 +52,6 @@ discretization = DiscontinuousGalerkin(linear_transport_flux, linear_transport_f
                                        inverse_transformation, LOCAL_SPACE_GRID_SIZE,
                                        LOCAL_TIME_GRID_SIZE)
 
-grid_operator = GridOperator(space_time_grid, discretization, DGFunction,
-                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
-                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
-
 
 def u_0_function(x, jumps=True):
     if jumps:
@@ -63,11 +59,14 @@ def u_0_function(x, jumps=True):
     return 0.5 * (1.0 + np.cos(2.0 * np.pi * x)) * (0.0 <= x <= 0.5) + 0. * (x > 0.5)
 
 
-u_0 = grid_operator.interpolate(u_0_function)
+grid_operator = GridOperator(space_time_grid, discretization, DGFunction, u_0_function,
+                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
+                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
 
-plot_space_function(u_0, title='Initial condition interpolated to DG space')
 
-u = grid_operator.solve(u_0)
+plot_space_function(grid_operator.u_0, title='Initial condition interpolated to DG space')
+
+u = grid_operator.solve()
 
 plot_space_time_function(u, inverse_transformation, title='Spacetime solution')
 

--- a/examples/linear_transport_1d_simplified.py
+++ b/examples/linear_transport_1d_simplified.py
@@ -47,10 +47,6 @@ discretization = DiscontinuousGalerkin(linear_transport_flux, linear_transport_f
                                        inverse_transformation, LOCAL_SPACE_GRID_SIZE,
                                        LOCAL_TIME_GRID_SIZE)
 
-grid_operator = GridOperator(space_time_grid, discretization, DGFunction,
-                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
-                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
-
 
 def u_0_function(x, jump=True):
     if jump:
@@ -58,11 +54,13 @@ def u_0_function(x, jump=True):
     return 0.5 * (1.0 + np.cos(2.0 * np.pi * x)) * (0.0 <= x <= 0.5) + 0. * (x > 0.5)
 
 
-u_0 = grid_operator.interpolate(u_0_function)
+grid_operator = GridOperator(space_time_grid, discretization, DGFunction, u_0_function,
+                             local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
+                             local_time_grid_size=LOCAL_TIME_GRID_SIZE)
 
-plot_space_function(u_0, title='Initial condition interpolated to DG space')
+plot_space_function(grid_operator.u_0, title='Initial condition interpolated to DG space')
 
-u = grid_operator.solve(u_0, discretization)
+u = grid_operator.solve()
 
 plot_space_time_function(u, inverse_transformation, title='Spacetime solution')
 

--- a/examples/uniform_grid_1d.py
+++ b/examples/uniform_grid_1d.py
@@ -53,21 +53,19 @@ def main(MU: float = Option(1., help='Parameter mu that determines the velocity.
                                            inverse_transformation, LOCAL_SPACE_GRID_SIZE,
                                            LOCAL_TIME_GRID_SIZE)
 
-    grid_operator = GridOperator(space_time_grid, discretization, DGFunction,
-                                 TimeStepperType=RungeKutta4,
-                                 local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
-                                 local_time_grid_size=LOCAL_TIME_GRID_SIZE)
-
     def u_0_function(x, jump=True):
         if jump:
             return 1. * (x <= 0.25)
         return 0.5 * (1.0 + np.cos(2.0 * np.pi * x)) * (0.0 <= x <= 0.5) + 0. * (x > 0.5)
 
-    u_0 = grid_operator.interpolate(u_0_function)
+    grid_operator = GridOperator(space_time_grid, discretization, DGFunction, u_0_function,
+                                 TimeStepperType=RungeKutta4,
+                                 local_space_grid_size=LOCAL_SPACE_GRID_SIZE,
+                                 local_time_grid_size=LOCAL_TIME_GRID_SIZE)
 
-    plot_space_function(u_0, title='Initial condition interpolated to DG space')
+    plot_space_function(grid_operator.u_0, title='Initial condition interpolated to DG space')
 
-    u = grid_operator.solve(u_0)
+    u = grid_operator.solve()
 
     plot_space_time_function(u, inverse_transformation,
                              title=r"Spacetime solution for $\mu=$" + str(MU),

--- a/tent_pitching/operators/grid_operator.py
+++ b/tent_pitching/operators/grid_operator.py
@@ -4,7 +4,7 @@ from tent_pitching.utils.logger import getLogger
 
 
 class GridOperator:
-    def __init__(self, space_time_grid, discretization, LocalSpaceFunctionType,
+    def __init__(self, space_time_grid, discretization, LocalSpaceFunctionType, u_0,
                  TimeStepperType=ExplicitEuler, local_space_grid_size=1e-1,
                  local_time_grid_size=1e-1):
         self.space_time_grid = space_time_grid
@@ -18,6 +18,9 @@ class GridOperator:
         self.LocalSpaceFunctionType = LocalSpaceFunctionType
         assert discretization.LocalSpaceFunctionType == self.LocalSpaceFunctionType
 
+        self.u_0 = self.interpolate(u_0)
+        assert isinstance(self.u_0, SpaceFunction)
+
         self.time_stepper = TimeStepperType(discretization, self.local_time_grid_size)
 
     def interpolate(self, u):
@@ -26,14 +29,12 @@ class GridOperator:
                                        u=u, local_space_grid_size=self.local_space_grid_size)
         return u_interpolated
 
-    def solve(self, u_0):
-        assert isinstance(u_0, SpaceFunction)
-
+    def solve(self):
         function = SpaceTimeFunction(self.space_time_grid, self.LocalSpaceFunctionType,
                                      local_space_grid_size=self.local_space_grid_size,
                                      local_time_grid_size=self.local_time_grid_size)
 
-        function.set_global_initial_value(u_0)
+        function.set_global_initial_value(self.u_0)
 
         logger = getLogger('tent_pitching.GridOperator')
 


### PR DESCRIPTION
Instead of calling
```
u = grid_operator.solve(u_0)
```
the initial condition `u_0` is now passed to the constructor of the grid operator. Hence, we can now call
```
u = grid_operator.solve()
```
to obtain the same solution. However, that means that changing the initial condition is a bit more difficult in the future.